### PR TITLE
Update EclipseSource.setup

### DIFF
--- a/EclipseSource.setup
+++ b/EclipseSource.setup
@@ -85,7 +85,7 @@
       <requirement
           name="org.eclipse.emf.ecp.view.mappingdmr.feature.source.feature.group"/>
       <requirement
-          name="org.eclipse.emfforms.view.annotation.feature.feature.group"/>
+          name="org.eclipse.emfforms.view.annotation.feature.source.feature.group"/>
       <repository
           url="http://download.eclipse.org/releases/mars"/>
       <repository


### PR DESCRIPTION
Install source feature for annotation view model. This is backward compatible to 1.6.x
